### PR TITLE
Fix resolving shared string if the string is empty or equals to "0"

### DIFF
--- a/src/FastExcelReader/Sheet.php
+++ b/src/FastExcelReader/Sheet.php
@@ -75,7 +75,7 @@ class Sheet
         }
 
         // Value is a shared string
-        if ($dataType === 's' && is_numeric($cellValue) && ($str = $this->excel->sharedString((int)$cellValue))) {
+        if ($dataType === 's' && is_numeric($cellValue) && null !== ($str = $this->excel->sharedString((int)$cellValue))) {
             $cellValue = $str;
         }
         $styleIdx = (int)$cell->getAttribute('s');


### PR DESCRIPTION
If shared string is empty or equals to "0", the condition was evaluated to boolean false. Therefore, the index of shared string was assigned as the cell value, instead of the string itself.