### PR TITLE
Read original value of cell when date cell contains non-date value

### DIFF
--- a/src/FastExcelReader/Sheet.php
+++ b/src/FastExcelReader/Sheet.php
@@ -117,11 +117,19 @@ class Sheet
 
             case 'd':
             case 'date':
-                // Value is a date and non-empty
-                if (!empty($cellValue)) {
-                    $value = $this->excel->formatDate($this->excel->timestamp($cellValue), null, $styleIdx);
+                $timestamp = $this->excel->timestamp($cellValue);
+
+                if ($timestamp || empty($cellValue)) {
+                    // Value is a date and non-empty
+                    if (!empty($cellValue)) {
+                        $value = $this->excel->formatDate($timestamp, null, $styleIdx);
+                    }
+                    $dataType = 'date';
+                } else {
+                    // Value is not a date, load its original value
+                    $value = (string) $cellValue;
+                    $dataType = 'string';
                 }
-                $dataType = 'date';
                 break;
 
             default:


### PR DESCRIPTION
If cell has date format but contains a value which is not a date, timestamp resolves to 0 and the original value of cell is lost. In Excel, however, the original value of cell is shown instead.
This PR introduces easy fix for this case, to keep the original cell value.