### PR TITLE
Properly handle absolute paths in target attributes

### DIFF
--- a/src/FastExcelReader/Excel.php
+++ b/src/FastExcelReader/Excel.php
@@ -156,7 +156,7 @@ class Excel implements InterfaceBookReader
             if ($this->xmlReader->nodeType === \XMLReader::ELEMENT && $this->xmlReader->name === 'Relationship') {
                 $type = basename($this->xmlReader->getAttribute('Type'));
                 if ($type) {
-                    $this->relations[$type][$this->xmlReader->getAttribute('Id')] = 'xl/' . $this->xmlReader->getAttribute('Target');
+                    $this->relations[$type][$this->xmlReader->getAttribute('Id')] = 'xl/' . ltrim($this->xmlReader->getAttribute('Target'), '/xl');
                 }
             }
         }


### PR DESCRIPTION
If XLSX file contains "Relationship"/worksheet element with target defined as absolute path i.e. `/xl/worksheets/sheet1.xml` lib produces number of warning as it tries load file as `xl/xl/worksheets/sheet1.xml` which does not exists.

I believe all what is needed to do is to trim '/xl' from beginning of target string 😉 as something very similar is done in PHPSpreadSheet lib: https://github.com/PHPOffice/PhpSpreadsheet/blob/5bcbc7db0c00c1351d4f2a9625e2e6f6240a58a9/src/PhpSpreadsheet/Reader/Xlsx.php#L368

Example file with absolute ref. 
[worksheet-referenced-with-absolute-path.xlsx](https://github.com/aVadim483/fast-excel-reader/files/13588895/worksheet-referenced-with-absolute-path.xlsx)
