### PR TITLE
Saner handling of numeric values

### DIFF
--- a/src/FastExcelReader/Sheet.php
+++ b/src/FastExcelReader/Sheet.php
@@ -166,14 +166,12 @@ class Sheet implements InterfaceSheetReader
 
                     // Check for numeric values
                     if (is_numeric($value)) {
-                        /** @noinspection TypeUnsafeComparisonInspection */
-                        if ($value == (int)$value) {
-                            $value = (int)$value;
+                        if (false !== $castedValue = filter_var($value, FILTER_VALIDATE_INT)) {
+                            $value = $castedValue;
                             $dataType = 'number';
                         }
-                        /** @noinspection TypeUnsafeComparisonInspection */
-                        elseif ($value == (float)$value) {
-                            $value = (float)$value;
+                        elseif (strlen($value) > 2 && !($value[0] === '0' && $value[1] !== '.') && false !== $castedValue = filter_var($value, FILTER_VALIDATE_FLOAT)) {
+                            $value = $castedValue;
                             $dataType = 'number';
                         }
                     }


### PR DESCRIPTION
Fixes: https://github.com/aVadim483/fast-excel-reader/issues/16

Changes handling of numeric values:
Value: Before -> After
- `01`: `(int) 1` -> `(string) '01'`
- `-1354.98879e+37436`: `-INF` -> `(string) '-1354.98879e+37436'`
- `01.4`: `(float) 01.4` -> `(string) '01.4'`


If this approach sounds reasonable to you I will add also tests for it 😉 