### PR TITLE
Prevent TypeError in Sheet::isActive()

### DIFF
--- a/src/FastExcelReader/Sheet.php
+++ b/src/FastExcelReader/Sheet.php
@@ -296,6 +296,10 @@ class Sheet implements InterfaceSheetReader
     {
         if ($this->active === null) {
             $this->_readHeader();
+
+            if ($this->active === null) {
+                $this->active = false;
+            }
         }
 
         return $this->active;


### PR DESCRIPTION
In https://github.com/aVadim483/fast-excel-reader/blob/53b2725954cabfa898b67e76ea36e873e870ad19/src/FastExcelReader/Sheet.php#L295-L302
`$this->active` gets set via https://github.com/aVadim483/fast-excel-reader/blob/53b2725954cabfa898b67e76ea36e873e870ad19/src/FastExcelReader/Sheet.php#L374

But if this line does not get executed, `$this->active` stays `null` which results in a PHP TypeError (because the method is required to return `bool`). Am not sure if this is the desired behaviour or in other words if 
https://github.com/aVadim483/fast-excel-reader/blob/53b2725954cabfa898b67e76ea36e873e870ad19/src/FastExcelReader/Sheet.php#L373-L375
actually should get executed for EVERY valid Excel file. But in our case it was not.

PS: I stumbled upon the int-cast. The method `isActive()` returns boolean but `_readHeader()` contains `$this->active = (int)$xmlReader->getAttribute('tabSelected');` - how can `$this->active` actually become a `bool`?