### PR TITLE
Fix XML parsing for self-closing dataValidation elements

### DIFF
--- a/src/FastExcelReader/Sheet.php
+++ b/src/FastExcelReader/Sheet.php
@@ -1965,6 +1965,16 @@ class Sheet implements InterfaceSheetReader
         $formula1 = null;
         $formula2 = null;
 
+        // Check if it's a self-closing tag
+        if ($xmlReader->isEmptyElement) {
+            return [
+                'type' => $type,
+                'sqref' => $sqref,
+                'formula1' => $formula1,
+                'formula2' => $formula2
+            ];
+        }
+
         // Handle child nodes like formula1 and formula2
         while ($xmlReader->read()) {
             if ($xmlReader->nodeType === \XMLReader::ELEMENT && $xmlReader->name === 'formula1') {
@@ -2005,6 +2015,16 @@ class Sheet implements InterfaceSheetReader
         $sqref = null;
         $formula1 = null;
         $formula2 = null;
+
+        // Check if it's a self-closing tag
+        if ($xmlReader->isEmptyElement) {
+            return [
+                'type' => $type,
+                'sqref' => $sqref,
+                'formula1' => $formula1,
+                'formula2' => $formula2
+            ];
+        }
 
         // Parse the attributes within the <x14:dataValidation> tag
         while ($xmlReader->read()) {


### PR DESCRIPTION
## Issue
The XML parser for Excel dataValidation elements incorrectly handled self-closing tags 
(e.g., `<dataValidation ... />`), causing validation rules to be merged incorrectly. 
When a self-closing validation element was encountered in the XML, the parser would 
continue reading and inadvertently merge attributes from the next validation rule.

## Solution
Added checks using `$xmlReader->isEmptyElement` to detect self-closing tags and 
immediately return the collected attributes without attempting to read child nodes. 
This ensures that each validation rule is properly separated and processed correctly, 
regardless of whether it uses self-closing syntax or standard opening/closing tags.

The fix has been applied to both the standard dataValidation parser and the extended 
dataValidation parser for consistency, though the issue primarily affects the standard parser.